### PR TITLE
First CI/CD worklow for building and pushing docker container

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -1,0 +1,26 @@
+name: Build and Push Docker Image
+on:
+  push:
+    branches:
+      - testing
+jobs:
+    Build-and-Push-Docker-Image:
+        runs-on: ubuntu-latest
+        steps:
+            - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+            - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+            - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+            - name: Check out repository code
+              uses: actions/checkout@v2
+            - name: Extract branch name
+              shell: bash
+              run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+              id: extract_branch
+            - name: Login to dockerhub
+              shell: bash
+              working-directory: ./cicd-workflows
+              env:
+                CURRENT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+                DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+                DOCKER_SECRET: ${{ secrets.DOCKER_SECRET }}
+              run: ./build-and-push-docker-images.sh

--- a/cicd-workflows/build-and-push-docker-images.sh
+++ b/cicd-workflows/build-and-push-docker-images.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -Ee                               # fail script, if single command fails
+set -u                                # unset variables are treated as errors
+set -f                                # no filename extension
+# set -x                                # verbose mode
+set -o pipefail                       # if a subcommand from a pipe fails, the whole pipe fails
+trap cleanup SIGINT SIGTERM ERR EXIT  # execute cleanup function at following signals
+
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)  # location of script
+WORKING_DIR=$(pwd -P)  # working directory
+
+cleanup() {
+    trap - SIGINT SIGTERM ERR EXIT
+    # script cleanup here
+    echo "🧹 Time for cleanup"
+
+    echo "❌ Logging out of dockerhub"
+    docker "logout"
+}
+
+echo "😊 This script is located at '${SOURCE_DIR}'."
+echo "😊 This script was exectued from '${WORKING_DIR}'."
+echo "😊 Executing branch is ${CURRENT_BRANCH}"
+
+if [ "${CURRENT_BRANCH}" = "master" ]; then
+   DOCKER_TAG="stable"
+else
+   DOCKER_TAG="${CURRENT_BRANCH}"
+fi
+
+DOCKER_IMAGENAME="imktk/imktk:${DOCKER_TAG}"
+DOCKER_FILE="${SOURCE_DIR}/../code"
+
+echo "🔧 Building and tagging docker image"
+docker build --tag  "${DOCKER_IMAGENAME}" "${DOCKER_FILE}"
+
+echo "🐋 Logging in to dockerhub"
+docker login --username="${DOCKER_USERNAME}" --password="${DOCKER_SECRET}"
+
+echo "👆 Pushing ${DOCKER_IMAGENAME} to dockerhub"
+docker push "${DOCKER_IMAGENAME}"
+
+echo "🌟 Script ended successfully"


### PR DESCRIPTION
Fixes #11 

- Ext. workflow  to prevent vendor lock-in
- Moving CI/CD workflows to bash scripts prevents vendor lock-in and
each script can be executed using different CI/CD providers such as
CircleCI, Gitlab or GitHub.
- Simply set environment variables and execute bash script.
- Additionally this enables local testing.